### PR TITLE
Add dynamic reconfigure support for individual markers detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin COMPONENTS
         pcl_conversions
         message_generation
         ${MSG_DEPS}
+        dynamic_reconfigure
         REQUIRED)
 
 find_package(Eigen REQUIRED)
@@ -31,6 +32,9 @@ pkg_check_modules(PC_TINYXML REQUIRED tinyxml)
 set(MSG_FILES AlvarMarker.msg AlvarMarkers.msg)
 add_message_files(DIRECTORY msg FILES ${MSG_FILES})
 generate_messages(DEPENDENCIES ${MSG_DEPS})
+
+# dynamic reconfigure support
+generate_dynamic_reconfigure_options(cfg/Params.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -49,6 +53,7 @@ catkin_package(
         cv_bridge
         pcl_ros
         pcl_conversions
+        dynamic_reconfigure
 )
 
 include_directories(include 

--- a/cfg/Params.cfg
+++ b/cfg/Params.cfg
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+PACKAGE = "ar_track_alvar"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("enabled", bool_t, 0, "Enable/disable tracking, unsubscribing from camera topic to stop openni processing", True)
+gen.add("max_frequency", double_t, 0, "Maximum processing rate; frames coming at a higher rate are discarded", 10.0, 1.0, 30.0)
+gen.add("marker_size", double_t, 0, "The width in centimeters of one side of the black square marker border", 10.0, 1.0, 100.0)
+gen.add("max_new_marker_error", double_t, 0, "A threshold determining when new markers can be detected under uncertainty", 0.08, 0.0, 2.0)
+gen.add("max_track_error", double_t, 0, "A threshold determining how much tracking error can be observed before an tag is considered to have disappeared", 0.2, 0.0, 4.0)
+
+# Second arg is node name it will run in (doc purposes only), third is generated filename prefix
+exit(gen.generate(PACKAGE, "ar_track_alvar_configure", "Params"))

--- a/nodes/IndividualMarkers.cpp
+++ b/nodes/IndividualMarkers.cpp
@@ -44,6 +44,8 @@
 #include <tf/transform_listener.h>
 #include <sensor_msgs/image_encodings.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <dynamic_reconfigure/server.h>
+#include <ar_track_alvar/ParamsConfig.h>
 
 namespace gm=geometry_msgs;
 namespace ata=ar_track_alvar;
@@ -69,6 +71,9 @@ tf::TransformListener *tf_listener;
 tf::TransformBroadcaster *tf_broadcaster;
 MarkerDetector<MarkerData> marker_detector;
 
+bool enableSwitched = false;
+bool enabled = true;
+double max_frequency;
 double marker_size;
 double max_new_marker_error;
 double max_track_error;
@@ -452,16 +457,30 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
   }
 }
 
+void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
+{
+  ROS_INFO("AR tracker reconfigured: %s %.2f %.2f %.2f %.2f", config.enabled ? "ENABLED" : "DISABLED",
+           config.max_frequency, config.marker_size, config.max_new_marker_error, config.max_track_error);
+
+  enableSwitched = enabled != config.enabled;
+
+  enabled = config.enabled;
+  max_frequency = config.max_frequency;
+  marker_size = config.marker_size;
+  max_new_marker_error = config.max_new_marker_error;
+  max_track_error = config.max_track_error;
+}
 
 int main(int argc, char *argv[])
 {
   ros::init (argc, argv, "marker_detect");
-  ros::NodeHandle n;
+  ros::NodeHandle n, pn("~");
 	
   if(argc < 7){
     std::cout << std::endl;
     cout << "Not enough arguments provided." << endl;
-    cout << "Usage: ./individualMarkers <marker size in cm> <max new marker error> <max track error> <cam image topic> <cam info topic> <output frame>" << endl;
+    cout << "Usage: ./individualMarkers <marker size in cm> <max new marker error> <max track error> "
+         << "<cam image topic> <cam info topic> <output frame> [ <max frequency> ]";
     std::cout << std::endl;
     return 0;
   }
@@ -475,6 +494,17 @@ int main(int argc, char *argv[])
   output_frame = argv[6];
   marker_detector.SetMarkerSize(marker_size);
 
+  if (argc > 7)
+    max_frequency = atof(argv[7]);
+
+  // Set dynamically configurable parameters so they don't get replaced by default values
+  pn.setParam("marker_size", marker_size);
+  pn.setParam("max_new_marker_error", max_new_marker_error);
+  pn.setParam("max_track_error", max_track_error);
+
+  if (argc > 7)
+    pn.setParam("max_frequency", max_frequency);
+
   cam = new Camera(n, cam_info_topic);
   tf_listener = new tf::TransformListener(n);
   tf_broadcaster = new tf::TransformBroadcaster();
@@ -482,14 +512,52 @@ int main(int argc, char *argv[])
   rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
   rvizMarkerPub2_ = n.advertise < visualization_msgs::Marker > ("ARmarker_points", 0);
 	
+  // Prepare dynamic reconfiguration
+  dynamic_reconfigure::Server < ar_track_alvar::ParamsConfig > server;
+  dynamic_reconfigure::Server<ar_track_alvar::ParamsConfig>::CallbackType f;
+
+  f = boost::bind(&configCallback, _1, _2);
+  server.setCallback(f);
+
   //Give tf a chance to catch up before the camera callback starts asking for transforms
+  // It will also reconfigure parameters for the first time, setting the default values
   ros::Duration(1.0).sleep();
   ros::spinOnce();	
 	 
-  ROS_INFO ("Subscribing to image topic");
-  cloud_sub_ = n.subscribe(cam_image_topic, 1, &getPointCloudCallback);
+  if (enabled == true)
+  {
+    // This always happens, as enable is true by default
+    ROS_INFO("Subscribing to image topic");
+    cloud_sub_ = n.subscribe(cam_image_topic, 1, &getPointCloudCallback);
+  }
 
-  ros::spin ();
+  // Run at the configured rate, discarding pointcloud msgs if necessary
+  ros::Rate rate(max_frequency);
+
+  while (ros::ok())
+  {
+    ros::spinOnce();
+    rate.sleep();
+
+    if (std::abs((rate.expectedCycleTime() - ros::Duration(1.0 / max_frequency)).toSec()) > 0.001)
+    {
+      // Change rate dynamically; if must be above 0, as 0 will provoke a segfault on next spinOnce
+      ROS_DEBUG("Changing frequency from %.2f to %.2f", 1.0 / rate.expectedCycleTime().toSec(), max_frequency);
+      rate = ros::Rate(max_frequency);
+    }
+
+    if (enableSwitched == true)
+    {
+      // Enable/disable switch: subscribe/unsubscribe to make use of pointcloud processing nodelet
+      // lazy publishing policy; in CPU-scarce computer as TurtleBot's laptop this is a huge saving
+      if (enabled == false)
+        cloud_sub_.shutdown();
+      else
+        cloud_sub_ = n.subscribe(cam_image_topic, 1, &getPointCloudCallback);
+
+      enableSwitched = false;
+    }
+  }
 
   return 0;
 }

--- a/nodes/IndividualMarkersNoKinect.cpp
+++ b/nodes/IndividualMarkersNoKinect.cpp
@@ -43,6 +43,8 @@
 #include <ar_track_alvar/AlvarMarkers.h>
 #include <tf/transform_listener.h>
 #include <sensor_msgs/image_encodings.h>
+#include <dynamic_reconfigure/server.h>
+#include <ar_track_alvar/ParamsConfig.h>
 
 using namespace alvar;
 using namespace std;
@@ -59,6 +61,9 @@ tf::TransformListener *tf_listener;
 tf::TransformBroadcaster *tf_broadcaster;
 MarkerDetector<MarkerData> marker_detector;
 
+bool enableSwitched = false;
+bool enabled = true;
+double max_frequency;
 double marker_size;
 double max_new_marker_error;
 double max_track_error;
@@ -199,16 +204,30 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 	}
 }
 
+void configCallback(ar_track_alvar::ParamsConfig &config, uint32_t level)
+{
+  ROS_INFO("AR tracker reconfigured: %s %.2f %.2f %.2f %.2f", config.enabled ? "ENABLED" : "DISABLED",
+           config.max_frequency, config.marker_size, config.max_new_marker_error, config.max_track_error);
+
+  enableSwitched = enabled != config.enabled;
+
+  enabled = config.enabled;
+  max_frequency = config.max_frequency;
+  marker_size = config.marker_size;
+  max_new_marker_error = config.max_new_marker_error;
+  max_track_error = config.max_track_error;
+}
 
 int main(int argc, char *argv[])
 {
 	ros::init (argc, argv, "marker_detect");
-	ros::NodeHandle n;
+	ros::NodeHandle n, pn("~");
 	
 	if(argc < 7){
 		std::cout << std::endl;
 		cout << "Not enough arguments provided." << endl;
-		cout << "Usage: ./individualMarkers <marker size in cm> <max new marker error> <max track error> <cam image topic> <cam info topic> <output frame>" << endl;
+		cout << "Usage: ./individualMarkersNoKinect <marker size in cm> <max new marker error> "
+		     << "<max track error> <cam image topic> <cam info topic> <output frame> [ <max frequency> ]";
 		std::cout << std::endl;
 		return 0;
 	}
@@ -222,21 +241,70 @@ int main(int argc, char *argv[])
     output_frame = argv[6];
 	marker_detector.SetMarkerSize(marker_size);
 
+  if (argc > 7)
+    max_frequency = atof(argv[7]);
+
+  // Set dynamically configurable parameters so they don't get replaced by default values
+  pn.setParam("marker_size", marker_size);
+  pn.setParam("max_new_marker_error", max_new_marker_error);
+  pn.setParam("max_track_error", max_track_error);
+
+  if (argc > 7)
+    pn.setParam("max_frequency", max_frequency);
+
 	cam = new Camera(n, cam_info_topic);
 	tf_listener = new tf::TransformListener(n);
 	tf_broadcaster = new tf::TransformBroadcaster();
 	arMarkerPub_ = n.advertise < ar_track_alvar::AlvarMarkers > ("ar_pose_marker", 0);
 	rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
 	
+  // Prepare dynamic reconfiguration
+  dynamic_reconfigure::Server < ar_track_alvar::ParamsConfig > server;
+  dynamic_reconfigure::Server<ar_track_alvar::ParamsConfig>::CallbackType f;
+
+  f = boost::bind(&configCallback, _1, _2);
+  server.setCallback(f);
+
 	//Give tf a chance to catch up before the camera callback starts asking for transforms
+  // It will also reconfigure parameters for the first time, setting the default values
 	ros::Duration(1.0).sleep();
 	ros::spinOnce();	
 	 
-	ROS_INFO ("Subscribing to image topic");
 	image_transport::ImageTransport it_(n);
-    	cam_sub_ = it_.subscribe (cam_image_topic, 1, &getCapCallback);
 
-	ros::spin ();
+  if (enabled == true)
+  {
+    // This always happens, as enable is true by default
+    ROS_INFO("Subscribing to image topic");
+    	cam_sub_ = it_.subscribe (cam_image_topic, 1, &getCapCallback);
+  }
+
+  // Run at the configured rate, discarding pointcloud msgs if necessary
+  ros::Rate rate(max_frequency);
+
+  while (ros::ok())
+  {
+    ros::spinOnce();
+    rate.sleep();
+
+    if (std::abs((rate.expectedCycleTime() - ros::Duration(1.0 / max_frequency)).toSec()) > 0.001)
+    {
+      // Change rate dynamically; if must be above 0, as 0 will provoke a segfault on next spinOnce
+      ROS_DEBUG("Changing frequency from %.2f to %.2f", 1.0 / rate.expectedCycleTime().toSec(), max_frequency);
+      rate = ros::Rate(max_frequency);
+    }
+
+    if (enableSwitched == true)
+    {
+      // Enable/disable switch: subscribe/unsubscribe to make use of pointcloud processing nodelet
+      // lazy publishing policy; in CPU-scarce computer as TurtleBot's laptop this is a huge saving
+      if (enabled == false)
+        cam_sub_.shutdown();
+      else
+        cam_sub_ = it_.subscribe(cam_image_topic, 1, &getCapCallback);
+      enableSwitched = false;
+    }
+  }
 
     return 0;
 }

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@ This package is a ROS wrapper for Alvar, an open source AR tag tracking library.
  <build_depend>tf2</build_depend>
  <build_depend>tinyxml</build_depend>
  <build_depend>visualization_msgs</build_depend>
+ <build_depend>dynamic_reconfigure</build_depend>
 
  <run_depend>cv_bridge</run_depend>
  <run_depend>geometry_msgs</run_depend>
@@ -43,6 +44,7 @@ This package is a ROS wrapper for Alvar, an open source AR tag tracking library.
  <run_depend>tf2</run_depend>
  <run_depend>tinyxml</run_depend>
  <run_depend>visualization_msgs</run_depend>
+ <run_depend>dynamic_reconfigure</run_depend>
 
 </package>
 


### PR DESCRIPTION
Sorry, I only did for individual markers, what is the only part I used.

My code is ros-formatted by eclipse, so maybe is a bit mesh up with tabs/spaces. I will be happy to pull request a fully ros-formatted code if you want.

The enable/disable switch subscribes/unsubscribes to camera topic, what at the same time stops the CPU-hungry depth image to pointcloud nodelet. When not subscribed, the lazy publishing of the pointcloud makes a huge saving on CPU.
