### PR TITLE
Use Eigen::aligned_allocator to fix 32bit align

### DIFF
--- a/include/ar_track_alvar/MarkerDetector.h
+++ b/include/ar_track_alvar/MarkerDetector.h
@@ -44,6 +44,7 @@ using std::rotate;
 #include <vector>
 #include <map>
 #include <cassert>
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -151,20 +152,20 @@ protected:
   Marker* _track_markers_at(size_t i) { return &track_markers->at(i); }
 
   void _swap_marker_tables() {
-		std::vector<M> *tmp_markers = markers;
+		std::vector<M, Eigen::aligned_allocator<M> > *tmp_markers = markers;
 		markers = track_markers;
 		track_markers = tmp_markers;
   }
 
 public:
 
-	std::vector<M> *markers;
-	std::vector<M> *track_markers;
+	std::vector<M, Eigen::aligned_allocator<M> > *markers;
+	std::vector<M, Eigen::aligned_allocator<M> > *track_markers;
 
 	/** Constructor */
   MarkerDetector() : MarkerDetectorImpl() {
-    markers = new std::vector<M>;
-    track_markers = new std::vector<M>;
+    markers = new std::vector<M, Eigen::aligned_allocator<M> >;
+    track_markers = new std::vector<M, Eigen::aligned_allocator<M> >;
 	}
 
 	/** Destructor */


### PR DESCRIPTION
Attempts to fix 32bit alignment error in Eigen related code by using the Eigen::aligned_allocator in all STL Containers with Eigen.

**NOTE:** I'm not entirely sure this is a proper fix - it's more the thing that finally made it not crash at quarter to midnight... BUT, I wanted to do the PR to see what you thought.

See these resources for more information than I understand (particularly the first):
- http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html
- (Cause 2:) http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html

2nd Note: This is not a completely informed fix ... it just seemed to finally fix the alignment error and make the program not crash on **32-bit 12.04 with groovy, catkin (no kinect)**.
