### PR TITLE
32bit Eigen fixes with kinect testing

### DIFF
--- a/include/ar_track_alvar/Marker.h
+++ b/include/ar_track_alvar/Marker.h
@@ -40,6 +40,7 @@
 #include "Bitset.h"
 #include <vector>
 #include "filter/kinect_filtering.h"
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -293,7 +294,8 @@ namespace alvar {
     class ALVAR_EXPORT MarkerIteratorImpl : public MarkerIterator {
   public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW    
-  MarkerIteratorImpl(typename std::vector<T>::const_iterator i) : _begin(i), _i(i) {
+  typedef typename std::vector<T, Eigen::aligned_allocator<T> >::const_iterator const_iterator_aligntype;
+  MarkerIteratorImpl(const_iterator_aligntype i) : _begin(i), _i(i) {
       _data = this;
     }
 
@@ -334,8 +336,8 @@ namespace alvar {
     }
 
   private:
-    typename std::vector<T>::const_iterator _begin;
-    typename std::vector<T>::const_iterator _i;
+    const_iterator_aligntype _begin;
+    const_iterator_aligntype _i;
   };
 
 } // namespace alvar

--- a/include/ar_track_alvar/MarkerDetector.h
+++ b/include/ar_track_alvar/MarkerDetector.h
@@ -44,6 +44,7 @@ using std::rotate;
 #include <vector>
 #include <map>
 #include <cassert>
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -151,20 +152,20 @@ protected:
   Marker* _track_markers_at(size_t i) { return &track_markers->at(i); }
 
   void _swap_marker_tables() {
-		std::vector<M> *tmp_markers = markers;
+		std::vector<M, Eigen::aligned_allocator<M> > *tmp_markers = markers;
 		markers = track_markers;
 		track_markers = tmp_markers;
   }
 
 public:
 
-	std::vector<M> *markers;
-	std::vector<M> *track_markers;
+	std::vector<M, Eigen::aligned_allocator<M> > *markers;
+	std::vector<M, Eigen::aligned_allocator<M> > *track_markers;
 
 	/** Constructor */
   MarkerDetector() : MarkerDetectorImpl() {
-    markers = new std::vector<M>;
-    track_markers = new std::vector<M>;
+    markers = new std::vector<M, Eigen::aligned_allocator<M> >;
+    track_markers = new std::vector<M, Eigen::aligned_allocator<M> >;
 	}
 
 	/** Destructor */

--- a/include/ar_track_alvar/MultiMarker.h
+++ b/include/ar_track_alvar/MultiMarker.h
@@ -37,6 +37,7 @@
 #include "Filter.h"
 #include "FileFormat.h"
 #include <tf/LinearMath/Vector3.h>
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -105,7 +106,7 @@ public:
 		\param image If != 0 some visualizations are drawn.
 	*/
 	template <class M>
-	double GetPose(const std::vector<M>* markers, Camera* cam, Pose& pose, IplImage* image = 0)
+	double GetPose(const std::vector<M, Eigen::aligned_allocator<M> >* markers, Camera* cam, Pose& pose, IplImage* image = 0)
 	{
 		MarkerIteratorImpl<M> begin(markers->begin());
 		MarkerIteratorImpl<M> end(markers->end());
@@ -116,7 +117,7 @@ public:
 	/** \brief Calls GetPose to obtain camera pose.
 	*/
 	template <class M>
-	double Update(const std::vector<M>* markers, Camera* cam, Pose& pose, IplImage* image = 0)
+	double Update(const std::vector<M, Eigen::aligned_allocator<M> >* markers, Camera* cam, Pose& pose, IplImage* image = 0)
 	{
 		if(markers->size() < 1) return -1.0;
 

--- a/include/ar_track_alvar/MultiMarkerBundle.h
+++ b/include/ar_track_alvar/MultiMarkerBundle.h
@@ -33,6 +33,7 @@
 
 #include "MultiMarker.h"
 #include "Optimization.h"
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -81,7 +82,7 @@ public:
 		\param camera_pose Current camera pose.
 	*/
 	template <class M>
-	void MeasurementsAdd(const std::vector<M> *markers, const Pose& camera_pose) {
+	void MeasurementsAdd(const std::vector<M, Eigen::aligned_allocator<M> > *markers, const Pose& camera_pose) {
 	    MarkerIteratorImpl<M> begin(markers->begin());
 	    MarkerIteratorImpl<M> end(markers->end());
         _MeasurementsAdd(begin, end,

--- a/include/ar_track_alvar/MultiMarkerInitializer.h
+++ b/include/ar_track_alvar/MultiMarkerInitializer.h
@@ -32,6 +32,7 @@
  */
 
 #include "MultiMarker.h"
+#include <Eigen/StdVector>
 
 namespace alvar {
 
@@ -63,12 +64,12 @@ public:
 
 protected:
 	std::vector<bool> marker_detected;
-	std::vector<std::vector<MarkerMeasurement> > measurements;
-	typedef std::vector<std::vector<MarkerMeasurement> >::iterator MeasurementIterator;
+	std::vector<std::vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > > measurements;
+	typedef std::vector<std::vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > >::iterator MeasurementIterator;
 	FilterMedian *pointcloud_filtered;
 	int filter_buffer_min;
 
-	bool updateMarkerPoses(std::vector<MarkerMeasurement> &markers, const Pose &pose);
+	bool updateMarkerPoses(std::vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > &markers, const Pose &pose);
 	void MeasurementsAdd(MarkerIterator &begin, MarkerIterator &end);
 
 public:
@@ -91,7 +92,7 @@ public:
 	 * and then the pose of B.
 	 */
 	template <class M>
-	void MeasurementsAdd(const std::vector<M> *markers) {
+	void MeasurementsAdd(const std::vector<M, Eigen::aligned_allocator<M> > *markers) {
 	    MarkerIteratorImpl<M> begin(markers->begin());
 	    MarkerIteratorImpl<M> end(markers->end());
         MeasurementsAdd(begin, end);
@@ -111,13 +112,15 @@ public:
 
 	int getMeasurementCount() { return measurements.size(); }
 
-	const std::vector<MarkerMeasurement>& getMeasurementMarkers(int measurement) { 
+	const std::vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> >& getMeasurementMarkers(int measurement) {
 		return measurements[measurement];
 	}
 
 	double getMeasurementPose(int measurement, Camera *cam, Pose &pose) {
-		MarkerIteratorImpl<MarkerMeasurement> m_begin(measurements[measurement].begin());
-		MarkerIteratorImpl<MarkerMeasurement> m_end(measurements[measurement].end());
+//	  std::vector<MarkerMeasurement>::const_iterator test_measure(measurements[measurement].begin());
+//    MarkerIteratorImpl<MarkerMeasurement> m_begin(test_measure);
+	  MarkerIteratorImpl<MarkerMeasurement> m_begin(measurements[measurement].begin());
+    MarkerIteratorImpl<MarkerMeasurement> m_end(measurements[measurement].end());
 		return _GetPose(m_begin, m_end, cam, pose, NULL);
 	}
 };

--- a/include/ar_track_alvar/MultiMarkerInitializer.h
+++ b/include/ar_track_alvar/MultiMarkerInitializer.h
@@ -117,10 +117,8 @@ public:
 	}
 
 	double getMeasurementPose(int measurement, Camera *cam, Pose &pose) {
-//	  std::vector<MarkerMeasurement>::const_iterator test_measure(measurements[measurement].begin());
-//    MarkerIteratorImpl<MarkerMeasurement> m_begin(test_measure);
-	  MarkerIteratorImpl<MarkerMeasurement> m_begin(measurements[measurement].begin());
-    MarkerIteratorImpl<MarkerMeasurement> m_end(measurements[measurement].end());
+		MarkerIteratorImpl<MarkerMeasurement> m_begin(measurements[measurement].begin());
+		MarkerIteratorImpl<MarkerMeasurement> m_end(measurements[measurement].end());
 		return _GetPose(m_begin, m_end, cam, pose, NULL);
 	}
 };

--- a/include/ar_track_alvar/filter/kinect_filtering.h
+++ b/include/ar_track_alvar/filter/kinect_filtering.h
@@ -54,6 +54,7 @@
 #include <pcl_ros/point_cloud.h>
 #include <pcl/filters/extract_indices.h>
 #include <boost/lexical_cast.hpp>
+#include <Eigen/StdVector>
 
 #include <opencv2/core/core.hpp>
 
@@ -69,14 +70,14 @@ typedef pcl::PointCloud<ARPoint> ARCloud;
 struct PlaneFitResult
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW  
-  PlaneFitResult () : inliers(boost::make_shared<ARCloud>()) {}
+  PlaneFitResult () : inliers(ARCloud::Ptr(new ARCloud)) {}
   ARCloud::Ptr inliers;
   pcl::ModelCoefficients coeffs;
 };
 
 // Select out a subset of a cloud corresponding to a set of pixel coordinates
 ARCloud::Ptr filterCloud (const ARCloud& cloud,
-                          const std::vector<cv::Point>& pixels);
+                          const std::vector<cv::Point, Eigen::aligned_allocator<cv::Point> >& pixels);
 
 // Wrapper for PCL plane fitting
 PlaneFitResult fitPlane (ARCloud::ConstPtr cloud);

--- a/nodes/FindMarkerBundles.cpp
+++ b/nodes/FindMarkerBundles.cpp
@@ -385,7 +385,7 @@ void GetMultiMarkerPoses(IplImage *image, ARCloud &cloud) {
       //printf("\n--------------------------\n\n");
       for (size_t i=0; i<marker_detector.markers->size(); i++)
     	{
-	  vector<cv::Point> pixels;
+	  vector<cv::Point, Eigen::aligned_allocator<cv::Point> > pixels;
 	  Marker *m = &((*marker_detector.markers)[i]);
 	  int id = m->GetId();
 	  //cout << "******* ID: " << id << endl;

--- a/nodes/IndividualMarkers.cpp
+++ b/nodes/IndividualMarkers.cpp
@@ -43,6 +43,7 @@
 #include <ar_track_alvar/AlvarMarkers.h>
 #include <tf/transform_listener.h>
 #include <sensor_msgs/image_encodings.h>
+#include <Eigen/StdVector>
 
 namespace gm=geometry_msgs;
 namespace ata=ar_track_alvar;
@@ -266,7 +267,7 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
       printf("\n--------------------------\n\n");
       for (size_t i=0; i<marker_detector.markers->size(); i++)
      	{
-	  vector<cv::Point> pixels;
+	  vector<cv::Point, Eigen::aligned_allocator<cv::Point> > pixels;
 	  Marker *m = &((*marker_detector.markers)[i]);
 	  int id = m->GetId();
 	  cout << "******* ID: " << id << endl;

--- a/nodes/TrainMarkerBundle.cpp
+++ b/nodes/TrainMarkerBundle.cpp
@@ -45,6 +45,7 @@
 #include <ar_track_alvar/AlvarMarkers.h>
 #include <tf/transform_listener.h>
 #include <sensor_msgs/image_encodings.h>
+#include <Eigen/StdVector>
 
 using namespace alvar;
 using namespace std;
@@ -144,7 +145,7 @@ double GetMultiMarkerPose(IplImage *image, Pose &pose) {
             for (int i = 0; i < multi_marker_init->getMeasurementCount(); ++i) {
                 Pose p2;
                 multi_marker_init->getMeasurementPose(i, cam, p2);
-                const std::vector<MultiMarkerInitializer::MarkerMeasurement> markers = multi_marker_init->getMeasurementMarkers(i);
+                const std::vector<MultiMarkerInitializer::MarkerMeasurement, Eigen::aligned_allocator<MultiMarkerInitializer::MarkerMeasurement> > markers = multi_marker_init->getMeasurementMarkers(i);
                 multi_marker_bundle->MeasurementsAdd(&markers, p2);
             }
             // Initialize the bundle adjuster with initial marker poses.

--- a/src/MultiMarkerInitializer.cpp
+++ b/src/MultiMarkerInitializer.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "ar_track_alvar/MultiMarkerInitializer.h"
+#include <Eigen/StdVector>
 
 using namespace std;
 
@@ -42,7 +43,7 @@ MultiMarkerInitializer::MultiMarkerInitializer(std::vector<int>& indices, int _f
 
 void MultiMarkerInitializer::MeasurementsAdd(MarkerIterator &begin, MarkerIterator &end) {
 	// copy markers into measurements.
-	vector<MarkerMeasurement> new_measurements;
+	vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > new_measurements;
 	for (MarkerIterator &i = begin.reset(); i != end; ++i) {
 		const Marker* marker = *i;
 		int index = get_id_index(marker->GetId()); 
@@ -95,7 +96,7 @@ int MultiMarkerInitializer::Initialize(Camera* cam) {
 		found_new = false;
 		// Iterate through all measurements, try to compute Pose for each.
 		for (MeasurementIterator mi = measurements.begin(); mi != measurements.end(); ++mi) {
-			vector<MarkerMeasurement> &markers = *mi;
+			vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > &markers = *mi;
 			Pose pose;
 			MarkerIteratorImpl<MarkerMeasurement> m_begin(markers.begin());
 			MarkerIteratorImpl<MarkerMeasurement> m_end(markers.end());
@@ -116,9 +117,9 @@ int MultiMarkerInitializer::Initialize(Camera* cam) {
 	return n_detected;
 }
 
-bool MultiMarkerInitializer::updateMarkerPoses(vector<MarkerMeasurement> &markers, const Pose &pose) {
+bool MultiMarkerInitializer::updateMarkerPoses(vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> > &markers, const Pose &pose) {
 	bool found_new = false;
-	for (vector<MarkerMeasurement>::iterator i = markers.begin(); i != markers.end(); ++i) {
+	for (vector<MarkerMeasurement, Eigen::aligned_allocator<MarkerMeasurement> >::iterator i = markers.begin(); i != markers.end(); ++i) {
 		MarkerMeasurement &marker = *i;
 		int id = marker.GetId();
 		int index = get_id_index(id);

--- a/src/kinect_filtering.cpp
+++ b/src/kinect_filtering.cpp
@@ -75,7 +75,7 @@ namespace ar_track_alvar
     return res;
   }
 
-  ARCloud::Ptr filterCloud (const ARCloud& cloud, const vector<cv::Point>& pixels)
+  ARCloud::Ptr filterCloud (const ARCloud& cloud, const vector<cv::Point, Eigen::aligned_allocator<cv::Point> >& pixels)
   {
     ARCloud::Ptr out(new ARCloud());
     //ROS_INFO("  Filtering %zu pixels", pixels.size());


### PR DESCRIPTION
This diff should enable ar_track_alvar to now work on 32bit machines with, or without a Kinect, (assuming you can fiddle enough with the Kinect itself to get it to publish properly).
This PR finishes the earlier attempt in #17, to fix the 32bit alignment issue, mostly due to Eigen.

Most of the errors had to do with STL containers containing Eigen objects, with one instance of changing a boost::make_shared<ARCloud> call to  ARCloud::Ptr.

See the commit messages and these sites for more details:
- http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html
- (Cause 2:) http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html

Testing:
All 4 executables (indiv / bundle, with / without kinect) were tested on a 32bit Ubuntu 12.04 system in Groovy, using the openni_launch packaged for the Kinect testing, and the Baxter hand camera for the noKinect testing.
