### PR TITLE
Added ar_track_alvar as dependency for medianFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ target_link_libraries(kinect_filtering ${catkin_LIBRARIES})
 add_dependencies(kinect_filtering ${GENCPP_DEPS})
 
 add_library(medianFilter src/medianFilter.cpp)
-target_link_libraries(medianFilter ${catkin_LIBRARIES})
+target_link_libraries(medianFilter ar_track_alvar ${catkin_LIBRARIES})
 add_dependencies(medianFilter ${GENCPP_DEPS})
 
 set(ALVAR_TARGETS ar_track_alvar individualMarkers individualMarkersNoKinect trainMarkerBundle findMarkerBundles findMarkerBundlesNoKinect createMarker ar_track_alvar)


### PR DESCRIPTION
This package wouldn't build on my machine (OS X 10.9) because of an error linking to ar_track_alvar. The fix was to add ar_track_alvar to 'target_link_libraries' for medianFilter.
