### PR TITLE
Fixed the medianFilter.so runtime linker error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ target_link_libraries(ar_track_alvar ${OpenCV_LIBS} tinyxml ${catkin_LIBRARIES})
 add_dependencies(ar_track_alvar ${GENCPP_DEPS})
 
 # Kinect filtering code
+set(KINECT_FILTERING_TARGETS kinect_filtering medianFilter)
+
 add_library(kinect_filtering src/kinect_filtering.cpp)
 target_link_libraries(kinect_filtering ${catkin_LIBRARIES})
 add_dependencies(kinect_filtering ${GENCPP_DEPS})
@@ -126,7 +128,7 @@ add_executable(createMarker src/SampleMarkerCreator.cpp)
 target_link_libraries(createMarker ar_track_alvar ${catkin_LIBRARIES})
 add_dependencies(createMarker ${PROJECT_NAME}_gencpp ${GENCPP_DEPS})
 
-install(TARGETS ${ALVAR_TARGETS}
+install(TARGETS ${ALVAR_TARGETS} ${KINECT_FILTERING_TARGETS}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
This applies the same fix as on the hydro-devel branch for the medianFilter.so runtime linker error
