### PR TITLE
fix calib_K using roi info,

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -257,7 +257,25 @@ void Camera::camInfoCallback (const sensor_msgs::CameraInfoConstPtr & cam_info)
             cvmSet(&calib_D, 2, 0, 0);
             cvmSet(&calib_D, 3, 0, 0);
         }
-		  
+	
+        bool adjust_binning = (cam_info_.binning_x > 1) || (cam_info_.binning_y > 1);
+        bool adjust_roi = (cam_info_.roi.x_offset != 0) || (cam_info_.roi.y_offset != 0);
+        if ( adjust_roi ) {
+            cvmSet(&calib_K, 0, 2, cvmGet(&calib_K, 0, 2) - cam_info_.roi.x_offset);
+            cvmSet(&calib_K, 1, 2, cvmGet(&calib_K, 1, 2) - cam_info_.roi.y_offset);
+        }
+        if ( adjust_binning ) {
+            if ( cam_info_.binning_x > 1) {
+                double scale_x = 1.0 / cam_info_.binning_x;
+                cvmSet(&calib_K, 0, 0, cvmGet(&calib_K, 0, 2) * scale_x);
+                cvmSet(&calib_K, 0, 2, cvmGet(&calib_K, 0, 2) * scale_x);
+            }
+            if ( cam_info_.binning_y > 1) {
+                double scale_y = 1.0 / cam_info_.binning_y;
+                cvmSet(&calib_K, 1, 1, cvmGet(&calib_K, 1, 2) * scale_y);
+                cvmSet(&calib_K, 1, 2, cvmGet(&calib_K, 1, 2) * scale_y);
+            }
+        }
 		getCamInfo_ = true;
     }
   }


### PR DESCRIPTION
Some robots, for example Baxter publishes camera_info with roi

```
        $ rostopic echo -n 1 /cameras/right_hand_camera/camera_info
        header: 
          seq: 2468773
          stamp: 
            secs: 1416402182
            nsecs: 127162000
          frame_id: /right_hand_camera
        height: 400
        width: 640
        distortion_model: plumb_bob
        D: [0.0153369206277, -0.0432553402055, -0.00118657118488,
        -0.00147661359656, 0.00896220693898]
        K: [403.911583563, 0.0, 631.065444573, 0.0, 403.911583563,
        375.688877091, 0.0, 0.0, 1.0]
        R: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
        P: [403.911583563, 0.0, 311.06544457300004, 0.0, 0.0,
        403.911583563, 175.688877091, 0.0, 0.0, 0.0, 1.0, 0.0]
        binning_x: 1
        binning_y: 1
        roi: 
          x_offset: 320
          y_offset: 200
          height: 400
          width: 640
          do_rectify: False

```

so we need to consider roi into intrinsic camera parameters.
see https://github.com/ros-perception/vision_opencv/blob/groovy-devel/image_geometry/src/pinhole_camera_model.cpp#L137
