### PR TITLE
Added time stamp to header

### DIFF
--- a/nodes/IndividualMarkers.cpp
+++ b/nodes/IndividualMarkers.cpp
@@ -450,6 +450,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 	  ar_pose_marker.id = id;
 	  arPoseMarkers_.markers.push_back (ar_pose_marker);	
 	}
+      arPoseMarkers_.header.stamp = image_msg->header.stamp;
       arMarkerPub_.publish (arPoseMarkers_);
     }
     catch (cv_bridge::Exception& e){


### PR DESCRIPTION
Previously each pose had a timestamp, but the whole message did not. By
including the timestamp for the whole message, it is now possible to use
the results of the ar_pose_marker topic with other messages using
message_filters::Synchronizer.
