### PR TITLE
Fixes issue #63.

### DIFF
--- a/include/ar_track_alvar/ConnectedComponents.h
+++ b/include/ar_track_alvar/ConnectedComponents.h
@@ -85,7 +85,7 @@ public :
 	Labeling();
 
 	/** Destructor*/
-	~Labeling();
+	virtual ~Labeling();
 
 	/**
 	 * \brief Sets the camera object that is used to correct lens distortions.


### PR DESCRIPTION
When you want to delete an instance of a derived class by deleting a pointer to the base class one needs to use virtual destructors. The only change required is in line 88 of ConnectedComponents.h

Currently the line reads: ~Labeling();
Fix: virtual ~Labeling();

After applying the fix, you can see that when the pointer labeling gets deleted, the destructor of the derived class is also being called, and the memory is being released.
