### PR TITLE
Compatible to ROS Kinetic Kame

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: generic
 
 compiler:
@@ -9,13 +9,11 @@ notifications:
   email:
     on_failure: always
     recipients:
-      - 130s@2000.jukuin.keio.ac.jp
+      - smohaime@sfu.ca
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,22 @@ find_package(catkin COMPONENTS
         cmake_modules
         REQUIRED)
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(TinyXML REQUIRED)
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+else()
+        message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
+cmake_policy(SET CMP0046 OLD)
 
 # dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/Params.cfg)

--- a/include/ar_track_alvar/Util.h
+++ b/include/ar_track_alvar/Util.h
@@ -41,6 +41,7 @@
 #include <cv.h>
 #include <cmath> //for abs
 #include <map>
+#include <opencv2/calib3d/calib3d_c.h> //Compatibility with OpenCV 3.x
 
 namespace alvar {
 

--- a/src/kinect_filtering.cpp
+++ b/src/kinect_filtering.cpp
@@ -84,7 +84,7 @@ namespace ar_track_alvar
       {
 	const cv::Point& p = pixels[i];
 	const ARPoint& pt = cloud(p.x, p.y);
-	if (isnan(pt.x) || isnan(pt.y) || isnan(pt.z)){
+	if (std::isnan(pt.x) || std::isnan(pt.y) || std::isnan(pt.z)){
 	  //ROS_INFO("    Skipping (%.4f, %.4f, %.4f)", pt.x, pt.y, pt.z);
 	}
 	else


### PR DESCRIPTION
Can be compiled with OpenCV 3.1.0 which is used by ROS Kinetic on Ubuntu 16.04
Used Eigen3 and Cpp-11 to suppress some warnings
Set CMake policy to remove dependencies warnings for CMake 3+  
