### PR TITLE
[kinetic-devel] Fix build for Kinetic by adding missing dependencies on gencfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,11 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
-    - ROS_DISTRO="indigo" PRERELEASE=true
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
-    - ROS_DISTRO="jade"   PRERELEASE=true
     - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" PRERELEASE=true
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
-    - env: ROS_DISTRO="indigo" PRERELEASE=true
-    - env: ROS_DISTRO="indigo" PRERELEASE=true
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu USE_DEB=true
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu USE_DEB=true
-    - env: ROS_DISTRO="jade"   PRERELEASE=true
-    - env: ROS_DISTRO="jade"   PRERELEASE=true  
+    - env: ROS_DISTRO="kinetic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,11 +123,11 @@ set(ALVAR_TARGETS ar_track_alvar individualMarkers individualMarkersNoKinect tra
 
 add_executable(individualMarkers nodes/IndividualMarkers.cpp)
 target_link_libraries(individualMarkers ar_track_alvar kinect_filtering ${catkin_LIBRARIES})
-add_dependencies(individualMarkers ${PROJECT_NAME}_gencpp ${GENCPP_DEPS})
+add_dependencies(individualMarkers ${PROJECT_NAME}_gencpp ${GENCPP_DEPS} ${PROJECT_NAME}_gencfg)
 
 add_executable(individualMarkersNoKinect nodes/IndividualMarkersNoKinect.cpp)
 target_link_libraries(individualMarkersNoKinect ar_track_alvar ${catkin_LIBRARIES})
-add_dependencies(individualMarkersNoKinect ${PROJECT_NAME}_gencpp  ${GENCPP_DEPS})
+add_dependencies(individualMarkersNoKinect ${PROJECT_NAME}_gencpp  ${GENCPP_DEPS} ${PROJECT_NAME}_gencfg)
 
 add_executable(trainMarkerBundle nodes/TrainMarkerBundle.cpp)
 target_link_libraries(trainMarkerBundle ar_track_alvar ${catkin_LIBRARIES})

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,9 @@
 <description>
 This package is a ROS wrapper for Alvar, an open source AR tag tracking library.
 </description>
+<author email="sniekum@cs.umass.edu">Scott Niekum</author>
 <maintainer email="sniekum@cs.umass.edu">Scott Niekum</maintainer>
+<maintainer email="130s@2000.jukuin.keio.ac.jp">Isaac I.Y. Saito</maintainer>
 <license>LGPL-2.1</license>
 <url type="website">http://ros.org/wiki/ar_track_alvar</url>
 


### PR DESCRIPTION
Replacing #82 against the correct branch, `kinetic-devel`.
