### PR TITLE
Shutdown camera info sub after called

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -263,6 +263,7 @@ void Camera::camInfoCallback (const sensor_msgs::CameraInfoConstPtr & cam_info)
     {
         SetCameraInfo(*cam_info);
         getCamInfo_ = true;
+        sub_.shutdown();
     }
   }
 


### PR DESCRIPTION
Disable camera info subscription after receiving the info.

This stops e. g. Asus Xtion from having an active subscription to the RGB image stream and thus saving CPU.

See also:
https://github.com/yujinrobot/ar_track_alvar/pull/2

Should be cherry picked into kinetic also
