### PR TITLE
individual marker nodes: replace command line args with ros parameters

### DIFF
--- a/launch/pr2_indiv.launch
+++ b/launch/pr2_indiv.launch
@@ -4,8 +4,17 @@
 	<arg name="max_track_error" default="0.2" />
 
 	<arg name="cam_image_topic" default="/kinect_head/depth_registered/points" />
-	<arg name="cam_info_topic" default="/kinect_head/rgb/camera_info" />		
+	<arg name="cam_info_topic" default="/kinect_head/rgb/camera_info" />
 	<arg name="output_frame" default="/torso_lift_link" />
 
-	<node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkers" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+	<node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkers" respawn="false" output="screen">
+		<param name="marker_size"           type="double" value="$(arg marker_size)" />
+		<param name="max_new_marker_error"  type="double" value="$(arg max_new_marker_error)" />
+		<param name="max_track_error"       type="double" value="$(arg max_track_error)" />
+		<param name="output_frame"          type="string" value="$(arg output_frame)" />
+
+		<remap from="camera_image"  to="$(arg cam_image_topic)" />
+		<remap from="camera_info"   to="$(arg cam_info_topic)" />
+	</node>
+
 </launch>

--- a/launch/pr2_indiv_no_kinect.launch
+++ b/launch/pr2_indiv_no_kinect.launch
@@ -3,8 +3,16 @@
 	<arg name="max_new_marker_error" default="0.08" />
 	<arg name="max_track_error" default="0.2" />
 	<arg name="cam_image_topic" default="/wide_stereo/left/image_color" />
-	<arg name="cam_info_topic" default="/wide_stereo/left/camera_info" />	
+	<arg name="cam_info_topic" default="/wide_stereo/left/camera_info" />
 	<arg name="output_frame" default="/torso_lift_link" />
 
-	<node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen" args="$(arg marker_size) $(arg max_new_marker_error) $(arg max_track_error) $(arg cam_image_topic) $(arg cam_info_topic) $(arg output_frame)" />
+	<node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen">
+		<param name="marker_size"           type="double" value="$(arg marker_size)" />
+		<param name="max_new_marker_error"  type="double" value="$(arg max_new_marker_error)" />
+		<param name="max_track_error"       type="double" value="$(arg max_track_error)" />
+		<param name="output_frame"          type="string" value="$(arg output_frame)" />
+
+		<remap from="camera_image"  to="$(arg cam_image_topic)" />
+		<remap from="camera_info"   to="$(arg cam_info_topic)" />
+	</node>
 </launch>

--- a/nodes/IndividualMarkers.cpp
+++ b/nodes/IndividualMarkers.cpp
@@ -79,8 +79,8 @@ double max_frequency;
 double marker_size;
 double max_new_marker_error;
 double max_track_error;
-std::string cam_image_topic; 
-std::string cam_info_topic; 
+std::string cam_image_topic;
+std::string cam_info_topic;
 std::string output_frame;
 int marker_resolution = 5; // default marker resolution
 int marker_margin = 2; // default marker margin
@@ -95,14 +95,14 @@ void draw3dPoints(ARCloud::Ptr cloud, string frame, int color, int id, double ra
   rvizMarker.header.stamp = ros::Time::now();
   rvizMarker.id = id;
   rvizMarker.ns = "3dpts";
-  
+
   rvizMarker.scale.x = rad;
   rvizMarker.scale.y = rad;
   rvizMarker.scale.z = rad;
-  
+
   rvizMarker.type = visualization_msgs::Marker::SPHERE_LIST;
   rvizMarker.action = visualization_msgs::Marker::ADD;
-  
+
   if(color==1){
     rvizMarker.color.r = 0.0f;
     rvizMarker.color.g = 1.0f;
@@ -121,7 +121,7 @@ void draw3dPoints(ARCloud::Ptr cloud, string frame, int color, int id, double ra
     rvizMarker.color.b = 0.0f;
     rvizMarker.color.a = 1.0;
   }
-  
+
   gm::Point p;
   for(int i=0; i<cloud->points.size(); i++){
     p.x = cloud->points[i].x;
@@ -129,7 +129,7 @@ void draw3dPoints(ARCloud::Ptr cloud, string frame, int color, int id, double ra
     p.z = cloud->points[i].z;
     rvizMarker.points.push_back(p);
   }
-  
+
   rvizMarker.lifetime = ros::Duration (1.0);
   rvizMarkerPub2_.publish (rvizMarker);
 }
@@ -138,21 +138,21 @@ void draw3dPoints(ARCloud::Ptr cloud, string frame, int color, int id, double ra
 void drawArrow(gm::Point start, tf::Matrix3x3 mat, string frame, int color, int id)
 {
   visualization_msgs::Marker rvizMarker;
-  
+
   rvizMarker.header.frame_id = frame;
-  rvizMarker.header.stamp = ros::Time::now(); 
+  rvizMarker.header.stamp = ros::Time::now();
   rvizMarker.id = id;
   rvizMarker.ns = "arrow";
-  
+
   rvizMarker.scale.x = 0.01;
   rvizMarker.scale.y = 0.01;
   rvizMarker.scale.z = 0.1;
-  
+
   rvizMarker.type = visualization_msgs::Marker::ARROW;
   rvizMarker.action = visualization_msgs::Marker::ADD;
-  
+
   for(int i=0; i<3; i++){
-    rvizMarker.points.clear();	
+    rvizMarker.points.clear();
     rvizMarker.points.push_back(start);
     gm::Point end;
     end.x = start.x + mat[0][i];
@@ -196,13 +196,13 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
   pose.pose.position = ata::centroid(*res.inliers);
 
   draw3dPoints(selected_points, cloud.header.frame_id, 1, id, 0.005);
-	  
-  //Get 2 points that point forward in marker x direction   
+
+  //Get 2 points that point forward in marker x direction
   int i1,i2;
-  if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) || 
+  if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) ||
      isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z))
     {
-      if(isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z) || 
+      if(isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z) ||
 	 isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
 	{
 	  return -1;
@@ -210,19 +210,19 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
       else{
 	i1 = 1;
 	i2 = 2;
-      }	
+      }
     }
   else{
     i1 = 0;
     i2 = 3;
   }
 
-  //Get 2 points the point forward in marker y direction   
+  //Get 2 points the point forward in marker y direction
   int i3,i4;
-  if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) || 
+  if(isnan(corners_3D[0].x) || isnan(corners_3D[0].y) || isnan(corners_3D[0].z) ||
      isnan(corners_3D[1].x) || isnan(corners_3D[1].y) || isnan(corners_3D[1].z))
     {
-      if(isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z) || 
+      if(isnan(corners_3D[3].x) || isnan(corners_3D[3].y) || isnan(corners_3D[3].z) ||
 	 isnan(corners_3D[2].x) || isnan(corners_3D[2].y) || isnan(corners_3D[2].z))
 	{
 	  return -1;
@@ -230,21 +230,21 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
       else{
 	i3 = 2;
 	i4 = 3;
-      }	
+      }
     }
   else{
     i3 = 1;
     i4 = 0;
   }
-   
+
   ARCloud::Ptr orient_points(new ARCloud());
   orient_points->points.push_back(corners_3D[i1]);
   draw3dPoints(orient_points, cloud.header.frame_id, 3, id+1000, 0.008);
-      
+
   orient_points->clear();
   orient_points->points.push_back(corners_3D[i2]);
   draw3dPoints(orient_points, cloud.header.frame_id, 2, id+2000, 0.008);
- 
+
   int succ;
   succ = ata::extractOrientation(res.coeffs, corners_3D[i1], corners_3D[i2], corners_3D[i3], corners_3D[i4], pose.pose.orientation);
   if(succ < 0) return -1;
@@ -261,7 +261,7 @@ int PlaneFitPoseImprovement(int id, const ARCloud &corners_3D, ARCloud::Ptr sele
   p.quaternion[1] = pose.pose.orientation.x;
   p.quaternion[2] = pose.pose.orientation.y;
   p.quaternion[3] = pose.pose.orientation.z;
-  p.quaternion[0] = pose.pose.orientation.w; 
+  p.quaternion[0] = pose.pose.orientation.w;
 
   return 0;
 }
@@ -271,7 +271,7 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
 
   //Detect and track the markers
   if (marker_detector.Detect(image, cam, true, false, max_new_marker_error,
-			     max_track_error, CVSEQ, true)) 
+			     max_track_error, CVSEQ, true))
     {
       ROS_DEBUG_STREAM("--------------------------");
       for (size_t i=0; i<marker_detector.markers->size(); i++)
@@ -283,18 +283,18 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
 
 	  int resol = m->GetRes();
 	  int ori = m->ros_orientation;
-      
+
 	  PointDouble pt1, pt2, pt3, pt4;
 	  pt4 = m->ros_marker_points_img[0];
 	  pt3 = m->ros_marker_points_img[resol-1];
 	  pt1 = m->ros_marker_points_img[(resol*resol)-resol];
 	  pt2 = m->ros_marker_points_img[(resol*resol)-1];
-	  
+
 	  m->ros_corners_3D[0] = cloud(pt1.x, pt1.y);
 	  m->ros_corners_3D[1] = cloud(pt2.x, pt2.y);
 	  m->ros_corners_3D[2] = cloud(pt3.x, pt3.y);
 	  m->ros_corners_3D[3] = cloud(pt4.x, pt4.y);
-	  
+
 	  if(ori >= 0 && ori < 4){
 	    if(ori != 0){
 	      std::rotate(m->ros_corners_3D.begin(), m->ros_corners_3D.begin() + ori, m->ros_corners_3D.end());
@@ -305,15 +305,15 @@ void GetMarkerPoses(IplImage *image, ARCloud &cloud) {
 
 	  //Get the 3D marker points
 	  BOOST_FOREACH (const PointDouble& p, m->ros_marker_points_img)
-	    pixels.push_back(cv::Point(p.x, p.y));	  
+	    pixels.push_back(cv::Point(p.x, p.y));
 	  ARCloud::Ptr selected_points = ata::filterCloud(cloud, pixels);
 
 	  //Use the kinect data to find a plane and pose for the marker
-	  int ret = PlaneFitPoseImprovement(i, m->ros_corners_3D, selected_points, cloud, m->pose);	
+	  int ret = PlaneFitPoseImprovement(i, m->ros_corners_3D, selected_points, cloud, m->pose);
 	}
     }
 }
-      
+
 
 
 void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
@@ -322,7 +322,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 
   //If we've already gotten the cam info, then go ahead
   if(cam->getCamInfo_){
-    //Convert cloud to PCL 
+    //Convert cloud to PCL
     ARCloud cloud;
     pcl::fromROSMsg(*msg, cloud);
 
@@ -358,12 +358,12 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
       }
 
       arPoseMarkers_.markers.clear ();
-      for (size_t i=0; i<marker_detector.markers->size(); i++) 
+      for (size_t i=0; i<marker_detector.markers->size(); i++)
 	{
 	  //Get the pose relative to the camera
-	  int id = (*(marker_detector.markers))[i].GetId(); 
+	  int id = (*(marker_detector.markers))[i].GetId();
 	  Pose p = (*(marker_detector.markers))[i].pose;
-                
+
 	  double px = p.translation[0]/100.0;
 	  double py = p.translation[1]/100.0;
 	  double pz = p.translation[2]/100.0;
@@ -379,7 +379,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
       tf::Transform m (tf::Quaternion::getIdentity (), markerOrigin);
       tf::Transform markerPose = t * m; // marker pose in the camera frame
 
-	  //Publish the transform from the camera to the marker		
+	  //Publish the transform from the camera to the marker
 	  std::string markerFrame = "ar_marker_";
 	  std::stringstream out;
 	  out << id;
@@ -387,7 +387,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 	  markerFrame += id_string;
 	  tf::StampedTransform camToMarker (t, image_msg->header.stamp, image_msg->header.frame_id, markerFrame.c_str());
 	  tf_broadcaster->sendTransform(camToMarker);
-				
+
 	  //Create the rviz visualization messages
 	  tf::poseTFToMsg (markerPose, rvizMarker_.pose);
 	  rvizMarker_.header.frame_id = image_msg->header.frame_id;
@@ -442,7 +442,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 	  rvizMarker_.lifetime = ros::Duration (1.0);
 	  rvizMarkerPub_.publish (rvizMarker_);
 
-	  //Get the pose of the tag in the camera frame, then the output frame (usually torso)				
+	  //Get the pose of the tag in the camera frame, then the output frame (usually torso)
 	  tf::Transform tagPoseOutput = CamToOutput * markerPose;
 
 	  //Create the pose marker messages
@@ -451,7 +451,7 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 	  ar_pose_marker.header.frame_id = output_frame;
 	  ar_pose_marker.header.stamp = image_msg->header.stamp;
 	  ar_pose_marker.id = id;
-	  arPoseMarkers_.markers.push_back (ar_pose_marker);	
+	  arPoseMarkers_.markers.push_back (ar_pose_marker);
 	}
       arPoseMarkers_.header.stamp = image_msg->header.stamp;
       arMarkerPub_.publish (arPoseMarkers_);
@@ -480,39 +480,59 @@ int main(int argc, char *argv[])
 {
   ros::init (argc, argv, "marker_detect");
   ros::NodeHandle n, pn("~");
-	
-  if(argc < 7){
-    std::cout << std::endl;
-    cout << "Not enough arguments provided." << endl;
-    cout << "Usage: ./individualMarkers <marker size in cm> <max new marker error> <max track error> "
-         << "<cam image topic> <cam info topic> <output frame> [ <max frequency> <marker_resolution> <marker_margin>]";
-    std::cout << std::endl;
-    return 0;
+
+  if(argc > 1) {
+    ROS_WARN("Command line arguments are deprecated. Consider using ROS parameters and remappings.");
+
+    if(argc < 7){
+      std::cout << std::endl;
+      cout << "Not enough arguments provided." << endl;
+      cout << "Usage: ./individualMarkers <marker size in cm> <max new marker error> <max track error> "
+           << "<cam image topic> <cam info topic> <output frame> [ <max frequency> <marker_resolution> <marker_margin>]";
+      std::cout << std::endl;
+      return 0;
+    }
+
+    // Get params from command line
+    marker_size = atof(argv[1]);
+    max_new_marker_error = atof(argv[2]);
+    max_track_error = atof(argv[3]);
+    cam_image_topic = argv[4];
+    cam_info_topic = argv[5];
+    output_frame = argv[6];
+
+    if (argc > 7) {
+      max_frequency = atof(argv[7]);
+      pn.setParam("max_frequency", max_frequency);
+    }
+    if (argc > 8)
+      marker_resolution = atoi(argv[8]);
+    if (argc > 9)
+      marker_margin = atoi(argv[9]);
+
+  } else {
+    // Get params from ros param server.
+    pn.param("marker_size", marker_size, 10.0);
+    pn.param("max_new_marker_error", max_new_marker_error, 0.08);
+    pn.param("max_track_error", max_track_error, 0.2);
+    pn.param("max_frequency", max_frequency, 8.0);
+    pn.setParam("max_frequency", max_frequency);  // in case it was not set.
+    pn.param("marker_resolution", marker_resolution, 5);
+    pn.param("marker_margin", marker_margin, 2);
+    if (!pn.getParam("output_frame", output_frame)) {
+      ROS_ERROR("Param 'output_frame' has to be set.");
+      exit(EXIT_FAILURE);
+    }
+
+    // Camera input topics. Use remapping to map to your camera topics.
+    cam_image_topic = "camera_image";
+    cam_info_topic = "camera_info";
   }
-
-  // Get params from command line
-  marker_size = atof(argv[1]);
-  max_new_marker_error = atof(argv[2]);
-  max_track_error = atof(argv[3]);
-  cam_image_topic = argv[4];
-  cam_info_topic = argv[5];
-  output_frame = argv[6];
-
-  if (argc > 7)
-    max_frequency = atof(argv[7]);
 
   // Set dynamically configurable parameters so they don't get replaced by default values
   pn.setParam("marker_size", marker_size);
   pn.setParam("max_new_marker_error", max_new_marker_error);
   pn.setParam("max_track_error", max_track_error);
-
-  if (argc > 7)
-    pn.setParam("max_frequency", max_frequency);
-
-  if (argc > 8)
-    marker_resolution = atoi(argv[8]);
-  if (argc > 9)
-    marker_margin = atoi(argv[9]);
 
   marker_detector.SetMarkerSize(marker_size, marker_resolution, marker_margin);
 
@@ -522,7 +542,7 @@ int main(int argc, char *argv[])
   arMarkerPub_ = n.advertise < ar_track_alvar_msgs::AlvarMarkers > ("ar_pose_marker", 0);
   rvizMarkerPub_ = n.advertise < visualization_msgs::Marker > ("visualization_marker", 0);
   rvizMarkerPub2_ = n.advertise < visualization_msgs::Marker > ("ARmarker_points", 0);
-	
+
   // Prepare dynamic reconfiguration
   dynamic_reconfigure::Server < ar_track_alvar::ParamsConfig > server;
   dynamic_reconfigure::Server<ar_track_alvar::ParamsConfig>::CallbackType f;
@@ -533,8 +553,8 @@ int main(int argc, char *argv[])
   //Give tf a chance to catch up before the camera callback starts asking for transforms
   // It will also reconfigure parameters for the first time, setting the default values
   ros::Duration(1.0).sleep();
-  ros::spinOnce();	
-	 
+  ros::spinOnce();
+
   if (enabled == true)
   {
     // This always happens, as enable is true by default


### PR DESCRIPTION
This PR changes the way the two individual marker nodes parse their program arguments: Instead of parsing command line arguments the ros parameter server is now used. The goal is to make these nodes more readable and also more easily extensible in the future.

**Note**: This change will require users to alter their launch files as shown in `launch/pr2_indiv.launch` and `launch/pr2_indiv_no_kinect.launch`.

[USE THIS LINK TO COMPARE CHANGES](https://github.com/sniekum/ar_track_alvar/pull/99/files?w=1)
