### PR TITLE
Add param to derive camera frame from pointcloud message frame

### DIFF
--- a/nodes/IndividualMarkers.cpp
+++ b/nodes/IndividualMarkers.cpp
@@ -75,6 +75,7 @@ MarkerDetector<MarkerData> marker_detector;
 
 bool enableSwitched = false;
 bool enabled = true;
+bool output_frame_from_msg;
 double max_frequency;
 double marker_size;
 double max_new_marker_error;
@@ -320,6 +321,10 @@ void getPointCloudCallback (const sensor_msgs::PointCloud2ConstPtr &msg)
 {
   sensor_msgs::ImagePtr image_msg(new sensor_msgs::Image);
 
+  // If desired, use the frame in the message's header.
+  if (output_frame_from_msg)
+    output_frame = msg->header.frame_id;
+
   //If we've already gotten the cam info, then go ahead
   if(cam->getCamInfo_){
     //Convert cloud to PCL
@@ -519,8 +524,11 @@ int main(int argc, char *argv[])
     pn.setParam("max_frequency", max_frequency);  // in case it was not set.
     pn.param("marker_resolution", marker_resolution, 5);
     pn.param("marker_margin", marker_margin, 2);
-    if (!pn.getParam("output_frame", output_frame)) {
-      ROS_ERROR("Param 'output_frame' has to be set.");
+    pn.param("output_frame_from_msg", output_frame_from_msg, false);
+
+    if (!output_frame_from_msg && !pn.getParam("output_frame", output_frame)) {
+      ROS_ERROR("Param 'output_frame' has to be set if the output frame is not "
+                "derived from the point cloud message.");
       exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
This PR is based on #99 

It adds a parameter to the `individualMarkers` node, that allows to derive the value for the `output_frame` from the point cloud message's header frame id. This is for example useful, when you have multiple cameras that are multiplexed to `ar_track_alvar` via [topic_tools/mux](http://wiki.ros.org/topic_tools/mux) and you want to have the marker pose always wrt. the currently selected camera. 

Furthermore, it avoids looking up the transform between `output_frame` and the point cloud frame when these frames are equal.