### PR TITLE
Add image timestamp to header of global markers message

### DIFF
--- a/nodes/IndividualMarkersNoKinect.cpp
+++ b/nodes/IndividualMarkersNoKinect.cpp
@@ -197,6 +197,8 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 			    ar_pose_marker.id = id;
 			    arPoseMarkers_.markers.push_back (ar_pose_marker);	
 			}
+			arPoseMarkers_.header.frame_id = output_frame;
+			arPoseMarkers_.header.stamp = image_msg->header.stamp;
 			arMarkerPub_.publish (arPoseMarkers_);
 		}
         catch (cv_bridge::Exception& e){


### PR DESCRIPTION
Currently only adding time to the individual markers within the
message, this causes issues with using common header based
synchronizers, e.g. for multiple cameras.