### PR TITLE
Added timestamp in the header (NoKinect node)

### DIFF
--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -207,6 +207,7 @@ void getCapCallback (const sensor_msgs::ImageConstPtr & image_msg)
 			    ar_pose_marker.id = id;
 			    arPoseMarkers_.markers.push_back (ar_pose_marker);
 			}
+			arPoseMarkers_.header.stamp = image_msg->header.stamp;
 			arMarkerPub_.publish (arPoseMarkers_);
 		}
         catch (cv_bridge::Exception& e){


### PR DESCRIPTION
Time Synchronization (message_filters) need a timestamp in the header of ar_pose_marker topic.
Previously, each marker had a timestamp but the whole message did not.